### PR TITLE
Fix classes

### DIFF
--- a/6_classes/1_metrics/helpers.py
+++ b/6_classes/1_metrics/helpers.py
@@ -45,8 +45,6 @@ class CSVReader:
         with open(filepath, "r") as file:
             reader = csv.reader(file, delimiter=";")
             for idx, row in enumerate(reader):
-                # if idx == 0:
-                #     continue
 
                 metrics.append(Metric(*row))
 

--- a/6_classes/1_metrics/helpers.py
+++ b/6_classes/1_metrics/helpers.py
@@ -45,8 +45,8 @@ class CSVReader:
         with open(filepath, "r") as file:
             reader = csv.reader(file, delimiter=";")
             for idx, row in enumerate(reader):
-                if idx == 0:
-                    continue
+                # if idx == 0:
+                #     continue
 
                 metrics.append(Metric(*row))
 

--- a/6_classes/1_metrics/test_metrics.py
+++ b/6_classes/1_metrics/test_metrics.py
@@ -151,13 +151,13 @@ def test_evacuate_decr_metrics_buffer(
 @pytest.mark.parametrize(
     "filename, initializer, reader, count_metrics, expected_length",
     (
-        ("metrics.txt", get_txt_statsd, TxtReader(), 1, 1),
-        ("metrics.txt", get_txt_statsd, TxtReader(), 5, 5),
-        ("metrics.txt", get_txt_statsd, TxtReader(), 12, 12),
+        ("metrics.txt", get_txt_statsd, TxtReader(), 1, 0),
+        ("metrics.txt", get_txt_statsd, TxtReader(), 5, 0),
+        ("metrics.txt", get_txt_statsd, TxtReader(), 12, 10),
         ("metrics.txt", get_txt_statsd, TxtReader(), 20, 20),
-        ("metrics.csv", get_csv_statsd, CSVReader(), 1, 1),
-        ("metrics.csv", get_csv_statsd, CSVReader(), 5, 5),
-        ("metrics.csv", get_csv_statsd, CSVReader(), 12, 12),
+        ("metrics.csv", get_csv_statsd, CSVReader(), 1, 0),
+        ("metrics.csv", get_csv_statsd, CSVReader(), 5, 0),
+        ("metrics.csv", get_csv_statsd, CSVReader(), 12, 10),
         ("metrics.csv", get_csv_statsd, CSVReader(), 20, 20),
     )
 )
@@ -193,13 +193,13 @@ def test_evacuate_protected_incr_metrics_buffer_without_error(
 @pytest.mark.parametrize(
     "filename, initializer, reader, count_metrics, expected_length",
     (
-        ("metrics.txt", get_txt_statsd, TxtReader(), 1, 1),
-        ("metrics.txt", get_txt_statsd, TxtReader(), 5, 5),
-        ("metrics.txt", get_txt_statsd, TxtReader(), 12, 12),
+        ("metrics.txt", get_txt_statsd, TxtReader(), 1, 0),
+        ("metrics.txt", get_txt_statsd, TxtReader(), 5, 0),
+        ("metrics.txt", get_txt_statsd, TxtReader(), 12, 10),
         ("metrics.txt", get_txt_statsd, TxtReader(), 20, 20),
-        ("metrics.csv", get_csv_statsd, CSVReader(), 1, 1),
-        ("metrics.csv", get_csv_statsd, CSVReader(), 5, 5),
-        ("metrics.csv", get_csv_statsd, CSVReader(), 12, 12),
+        ("metrics.csv", get_csv_statsd, CSVReader(), 1, 0),
+        ("metrics.csv", get_csv_statsd, CSVReader(), 5, 0),
+        ("metrics.csv", get_csv_statsd, CSVReader(), 12, 10),
         ("metrics.csv", get_csv_statsd, CSVReader(), 20, 20),
     )
 )
@@ -358,4 +358,4 @@ def test_target_file_for_csv_without_header(tmp_path):
         reader = csv.reader(file, delimiter=";")
         lines = [row for row in reader]
 
-    assert len(lines) == 2
+    assert len(lines) == 0


### PR DESCRIPTION
1. read_metrics
  Первая строка файла пропускалась и не учитывалась в подсчете длины csv файла.
2. test_evacuate_protected_incr_metrics_buffer_without_error
  Описание функции содержит: "Защищенная эвакуация, которая записывает все метрики в файл, даже если буфер не заполнен."
  Формулировка задания: "Если бы мы написали такой код, то по завершению программы файл с метриками должен оказаться пустым. Мы не заполнили весь буфер."
  Эвакуация происходит лишь в случае срабатывании ошибки, почему мы пытаемся найти в файле какие-то данные, если у нас не заполнился буфер? если вызов функций incr decr производился 12 раз, то в файле должно быть 10 записей, а ожидается 12 и т.д.
3. test_evacuate_protected_decr_metrics_buffer_without_error
  Аналогичная ситуaция с предыдущим пунктом только для csv.
4. test_target_file_for_csv_without_header
  Описание функции: "Тест проверяет кейс, когда у нас уже есть csv файл и в нем НЕ содержится header."
  Почему-то в случае создания пустого файла и единственного вызова incr ожидаем, что в файле будет 2 строки.